### PR TITLE
Configure direnv to set Node version automatically

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -9,3 +9,11 @@ DB_SYNCHRONIZE=true
 export INTERSERVICE_TRANSPORT_CONFIG='{"transport": 2,"options": {"url": "nats://localhost:4222","queue": "authorization"}}'
 export VAULT_ADDR=http://127.0.0.1:8200
 export VAULT_TOKEN=mytoken
+
+nvmrc=~/.nvm/nvm.sh
+if [ -e $nvmrc ]; then
+  source $nvmrc
+  nvm use 14.17.6
+fi
+
+PATH_add node_modules/.bin


### PR DESCRIPTION
Why:
* It's unreliable to rely on the system Node version, or the version of Node selected externally from the service

How:
* Update the `.envrc` example file to include the script to auto-select the required version of Node

Notes:
* This is largely ornamental, as we have another repository that populates the real `.envrc` during startup
* We've decided, in the private environment that is the primary user of this service, to use NVM
* If any other environments that don't use NVM become users of this service, this section should change to be agnostic to NVM